### PR TITLE
Fixed nullpointerexception in RubricsFragment

### DIFF
--- a/app/src/main/java/be/hogent/tile3/rubricapplication/fragments/RubricFragment.kt
+++ b/app/src/main/java/be/hogent/tile3/rubricapplication/fragments/RubricFragment.kt
@@ -37,7 +37,7 @@ class RubricFragment : Fragment() {
         val rootView = inflater.inflate(R.layout.fragment_rubric, container, false)
 
         arguments?.let {
-            rubric = it.getSerializable(ARG_RUBRIC) as Rubric
+            rubric = it.getParcelable(ARG_RUBRIC) as Rubric
         }
 
         return rootView


### PR DESCRIPTION
…face for sharing rubrics between fragments. This fixes the nullpointer-exception since we removed the Serialize-interface from the models